### PR TITLE
fix(events): Include events starting now in print window

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -203,7 +203,7 @@ async function main(argv, { getNextEvent, getAllAttendees, createAndPrintPdf }) 
     const timeDiff = eventDate.getTime() - now.getTime();
     const minutesDiff = Math.floor(timeDiff / 1000 / 60);
 
-    if (minutesDiff <= printWindowMinutes && minutesDiff > 0) {
+    if (minutesDiff <= printWindowMinutes && minutesDiff >= 0) {
       logger.info(`Event "${event.name}" is starting in ${minutesDiff} minutes. Generating printout...`);
       const attendees = await getAllAttendees(event.id);
       if (attendees) {

--- a/functions.test.js
+++ b/functions.test.js
@@ -80,6 +80,21 @@ describe('main', () => {
 
     expect(createAndPrintPdfMock).toHaveBeenCalledTimes(1);
   });
+
+  it('should run and print a PDF if an event is starting now (0 minutes diff)', async () => {
+    const fakeNow = new Date();
+    // Event starts exactly now
+    const eventDate = new Date(fakeNow.getTime());
+    const mockEvent = { id: 1, name: 'Test Event', startDate: eventDate.toISOString() };
+
+    fs.readFileSync.mockReturnValue(JSON.stringify({ printWindowMinutes: 15 }));
+    getNextEventMock.mockResolvedValue(mockEvent);
+    getAllAttendeesMock.mockResolvedValue([{}]);
+
+    await funcs.main({}, { getNextEvent: getNextEventMock, getAllAttendees: getAllAttendeesMock, createAndPrintPdf: createAndPrintPdfMock });
+
+    expect(createAndPrintPdfMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('getNextEvent', () => {


### PR DESCRIPTION
The logic to determine if an event was within the print window used a strict `> 0` check on the minute difference. This meant that if the script ran at the exact moment an event was scheduled to start (0 minutes difference), the printout would not be generated.

This commit changes the condition to `>= 0` to correctly include events that are starting at the present time.

A new test case has been added to verify that an event with a 0-minute difference is now correctly processed.