### PR TITLE
fix: Include events starting at the exact run time

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -203,7 +203,7 @@ async function main(argv, { getNextEvent, getAllAttendees, createAndPrintPdf }) 
     const timeDiff = eventDate.getTime() - now.getTime();
     const minutesDiff = Math.floor(timeDiff / 1000 / 60);
 
-    if (minutesDiff <= printWindowMinutes && minutesDiff > 0) {
+    if (minutesDiff <= printWindowMinutes && minutesDiff >= 0) {
       logger.info(`Event "${event.name}" is starting in ${minutesDiff} minutes. Generating printout...`);
       const attendees = await getAllAttendees(event.id);
       if (attendees) {

--- a/functions.test.js
+++ b/functions.test.js
@@ -51,6 +51,21 @@ describe('main', () => {
     expect(createAndPrintPdfMock).not.toHaveBeenCalled();
   });
 
+  it('should run and print a PDF if an event is starting now (exactly 0 minutes away)', async () => {
+    const fakeNow = new Date();
+    // Event starts exactly now
+    const eventDate = new Date(fakeNow.getTime());
+    const mockEvent = { id: 1, name: 'Test Event Starting Now', startDate: eventDate.toISOString() };
+
+    fs.readFileSync.mockReturnValue(JSON.stringify({ printWindowMinutes: 15 }));
+    getNextEventMock.mockResolvedValue(mockEvent);
+    getAllAttendeesMock.mockResolvedValue([{}]);
+
+    await funcs.main({}, { getNextEvent: getNextEventMock, getAllAttendees: getAllAttendeesMock, createAndPrintPdf: createAndPrintPdfMock });
+
+    expect(createAndPrintPdfMock).toHaveBeenCalledTimes(1);
+  });
+
   it('should exit if config is invalid', async () => {
     const process = require('process');
     const processExitMock = jest.spyOn(process, 'exit').mockImplementation(() => {});


### PR DESCRIPTION
The previous logic for checking if an event was within the print window used the condition `minutesDiff > 0`. This excluded events that were starting at the exact moment the script was run (i.e., `minutesDiff` was 0).

This change modifies the condition to `minutesDiff >= 0` to ensure that events starting "now" are correctly processed and have their attendee lists printed.

A new test case has been added to verify that an event with a start time equal to the current time is correctly handled.