### PR TITLE
fix: Handle single category argument correctly

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -187,7 +187,7 @@ async function main(argv, { getNextEvent, getAllAttendees, createAndPrintPdf }) 
 
   const finalConfig = {
     printWindowMinutes: argv.window || validatedConfig.printWindowMinutes,
-    allowedCategories: argv.category || validatedConfig.categories,
+    allowedCategories: argv.category ? [].concat(argv.category) : validatedConfig.categories,
     outputFilename: argv.output || validatedConfig.outputFilename,
     pdfLayout: validatedConfig.pdfLayout,
     printMode: argv.printMode || 'email',

--- a/functions.test.js
+++ b/functions.test.js
@@ -110,6 +110,21 @@ describe('main', () => {
 
     expect(createAndPrintPdfMock).toHaveBeenCalledTimes(1);
   });
+
+  it('should handle a single category from argv', async () => {
+    const fakeNow = new Date();
+    const eventDate = new Date(fakeNow.getTime() + 10 * 60 * 1000);
+    const mockEvent = { id: 1, name: 'Test Event', startDate: eventDate.toISOString(), categories: [{ name: 'SingleCat' }] };
+
+    fs.readFileSync.mockReturnValue(JSON.stringify({}));
+    getNextEventMock.mockResolvedValue(mockEvent);
+    getAllAttendeesMock.mockResolvedValue([{}]);
+
+    await funcs.main({ category: 'SingleCat' }, { getNextEvent: getNextEventMock, getAllAttendees: getAllAttendeesMock, createAndPrintPdf: createAndPrintPdfMock });
+
+    expect(getNextEventMock).toHaveBeenCalledWith(['SingleCat']);
+    expect(createAndPrintPdfMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('getNextEvent', () => {


### PR DESCRIPTION
When providing a single category via the `--category` command-line argument, it was being treated as a string instead of an array. This caused a runtime error in the `getNextEvent` function, which expects an array of categories.

This commit fixes the issue by ensuring that the `allowedCategories` variable in the `main` function is always an array, even when only a single category is provided. It uses `[].concat()` to wrap the `argv.category` value in an array if it's not already one.

A new test case has been added to verify that the fix works as expected and does not introduce any regressions.