### PR TITLE
Fix: Use nullish coalescing for config loading

### DIFF
--- a/__tests__/functions.test.js
+++ b/__tests__/functions.test.js
@@ -249,6 +249,7 @@ describe('Event Processing Logic', () => {
             expect(mockDb.prepare).toHaveBeenCalledWith("UPDATE events SET status = 'processed' WHERE id = ?");
             expect(mockStmt.run).toHaveBeenCalledWith(1);
         });
+
     });
 
     describe('getAllAttendees', () => {

--- a/index.js
+++ b/index.js
@@ -41,13 +41,13 @@ async function main() {
     // Build the final configuration by merging config file, defaults, and command-line arguments
     const finalConfig = {
         // For fetch-events
-        allowedCategories: argv.category || validatedConfig.categories,
-        fetchWindowHours: argv.fetchWindowHours || validatedConfig.fetchWindowHours,
+        allowedCategories: argv.category ?? validatedConfig.categories,
+        fetchWindowHours: argv.fetchWindowHours ?? validatedConfig.fetchWindowHours,
         // For process-schedule
-        preEventQueryMinutes: argv.preEventQueryMinutes || validatedConfig.preEventQueryMinutes,
-        outputFilename: argv.output || validatedConfig.outputFilename,
+        preEventQueryMinutes: argv.preEventQueryMinutes ?? validatedConfig.preEventQueryMinutes,
+        outputFilename: argv.output ?? validatedConfig.outputFilename,
         pdfLayout: validatedConfig.pdfLayout,
-        printMode: argv.printMode || 'email'
+        printMode: argv.printMode ?? 'email'
     };
 
     logger.info(`Executing command: ${command}`);


### PR DESCRIPTION
Replaced the logical OR (`||`) operator with the nullish coalescing operator (`??`) when merging command-line arguments into the final configuration in `index.js`.

The `||` operator treats `0` as a falsy value, which caused a bug where a user-provided command-line argument of `0` would be incorrectly ignored in favor of the default value from `config.json`.

The `??` operator only falls back for `null` or `undefined`, correctly treating `0` as a valid user-provided value.