### PR TITLE
fix(pdf): Handle epoch timestamp for signUpDate

### DIFF
--- a/__tests__/pdf-generator.test.js
+++ b/__tests__/pdf-generator.test.js
@@ -62,6 +62,13 @@ describe('PdfGenerator', () => {
         expect(result).toBe('');
     });
 
+    it('should correctly format a signUpDate of 0 (Unix epoch)', () => {
+        const attendee = { signUpDate: 0 };
+        const result = generator['_getAttendeeValue'](attendee, 'signUpDate');
+        const expectedDate = new Date(0).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+        expect(result).toBe(expectedDate); // Should be '01 Jan 1970'
+    });
+
     it('should return fee for an attendee with fee', () => {
         const attendee = { hasFee: true, rule: { fee: 15.5 } };
         const result = generator['_getAttendeeValue'](attendee, 'fee');

--- a/pdf-generator.js
+++ b/pdf-generator.js
@@ -89,7 +89,8 @@ class PdfGenerator {
       case 'phone':
         return attendee.phone || '';
       case 'signUpDate':
-        if (!attendee.signUpDate) {
+        // Allow for a signUpDate of 0 (unix epoch) but not null or undefined
+        if (attendee.signUpDate == null) {
           return '';
         }
         return new Date(attendee.signUpDate).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });


### PR DESCRIPTION
The _getAttendeeValue function incorrectly treated a signUpDate of 0 (the Unix epoch) as a falsy value, causing it to return an empty string instead of the formatted date.

This was caused by the `if (!attendee.signUpDate)` check. This has been changed to `if (attendee.signUpDate == null)` to correctly handle `null` and `undefined` while allowing `0` to be processed as a valid timestamp.

A test case has been added to verify that a signUpDate of 0 is formatted correctly.