### PR TITLE
fix: Handle string fees in PDF generator

### DIFF
--- a/__tests__/pdf-generator.test.js
+++ b/__tests__/pdf-generator.test.js
@@ -98,5 +98,11 @@ describe('PdfGenerator', () => {
         const result = generator['_getAttendeeValue'](attendee, 'status');
         expect(result).toBe('No Fee');
     });
+
+    it('should handle a string fee gracefully', () => {
+        const attendee = { hasFee: true, rule: { fee: "15.5" } };
+        const result = generator['_getAttendeeValue'](attendee, 'fee');
+        expect(result).toBe('15.50');
+    });
   });
 });

--- a/pdf-generator.js
+++ b/pdf-generator.js
@@ -95,7 +95,7 @@ class PdfGenerator {
         }
         return new Date(attendee.signUpDate).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
       case 'fee':
-        return attendee.hasFee && attendee.rule && attendee.rule.fee ? `${attendee.rule.fee.toFixed(2)}` : '';
+        return attendee.hasFee && attendee.rule && attendee.rule.fee ? `${parseFloat(attendee.rule.fee).toFixed(2)}` : '';
       case 'status':
         return attendee.isPaid ? 'Paid' : (attendee.hasFee ? 'Owing' : 'No Fee');
       default:


### PR DESCRIPTION
The PDF generator would crash with a TypeError if an attendee's fee was represented as a string instead of a number.

This was because the code called .toFixed() directly on the fee value without ensuring it was a number type first.

This change fixes the bug by using parseFloat() to convert the fee to a number before formatting it, preventing the crash.

A test case has been added to verify the fix and prevent regressions.