### PR TITLE
fix: Correct datatype for event ID in database schema

### DIFF
--- a/database.js
+++ b/database.js
@@ -18,7 +18,7 @@ const getDb = () => {
 
       // Ensure the 'events' table exists.
       db.exec(`CREATE TABLE IF NOT EXISTS events (
-        id INTEGER PRIMARY KEY,
+        id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         startDate TEXT NOT NULL,
         status TEXT NOT NULL DEFAULT 'pending'

--- a/migrations/001-initial-schema.sql
+++ b/migrations/001-initial-schema.sql
@@ -1,6 +1,6 @@
 -- Up
 CREATE TABLE IF NOT EXISTS events (
-    id INTEGER PRIMARY KEY,
+    id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     startDate TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending'


### PR DESCRIPTION
The application was failing with a `SqliteError: datatype mismatch` because it was attempting to insert a string-based event ID (e.g., '67f22111f7a24ce9d2e4e464') into an `events` table column defined with the `INTEGER` data type.

This commit resolves the issue by changing the `id` column's data type from `INTEGER` to `TEXT` in the schema definition. The change is applied to both the on-the-fly table creation in `database.js` and the formal migration script in `migrations/001-initial-schema.sql` to ensure consistency.