### PR TITLE
Fix pm2 start command and correct axios-retry import

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,11 @@ npm install pm2 -g
 **2. Start the Service**
 Navigate to the project directory and use the following command to start the application with PM2.
 ```bash
-pm2 start npm --name "hello-club-service" -- run start
+pm2 start src/index.js --name "hello-club-service" -- -- start-service
 ```
-- `pm2 start npm`: Tells PM2 to use `npm` to execute the `start` script from `package.json`.
+- `pm2 start src/index.js`: Tells PM2 to execute the main script at `src/index.js`. Using the script file directly is more reliable than using `npm` across different platforms.
 - `--name "hello-club-service"`: Gives the process a memorable name.
+- `-- -- start-service`: The double dash (`--`) separates `pm2` options from your script's arguments. `start-service` is the command passed to your application.
 
 **3. Enable Automatic Startup**
 To ensure the service restarts when your computer reboots, run this command and follow the on-screen instructions:

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -4,7 +4,7 @@ const logger = require('./logger');
 const API_KEY = process.env.API_KEY;
 const BASE_URL = process.env.API_BASE_URL || 'https://api.helloclub.com';
 
-const axiosRetry = require('axios-retry');
+const axiosRetry = require('axios-retry').default;
 
 const api = axios.create({
   baseURL: BASE_URL,


### PR DESCRIPTION
- Updated the `README.md` with the correct `pm2` command to start the application as a service. The previous command was causing a "Script not found" error on some platforms. The new command directly targets the `src/index.js` file, which is more reliable.

- Corrected the import for `axios-retry` in `src/api-client.js`. The previous import was causing a `TypeError` because of a change in how the module is exported. This change ensures that the API client can handle request retries correctly.